### PR TITLE
catch TypeError too

### DIFF
--- a/pyembroidery/EmbEncoder.py
+++ b/pyembroidery/EmbEncoder.py
@@ -34,7 +34,7 @@ class Transcoder:
             try:
                 m = get_scale(scale[0], scale[1])
                 self.matrix = matrix_multiply(self.matrix, m)
-            except IndexError:
+            except (IndexError, TypeError):
                 try:
                     m = get_scale(scale.x, scale.y)
                     self.matrix = matrix_multiply(self.matrix, m)


### PR DESCRIPTION
If you pass a single float or integer as the scale, it'll raise a TypeError, so let's catch that too.