### PR TITLE
Remove invalid trim command from ExpWriter.

### DIFF
--- a/pyembroidery/ExpWriter.py
+++ b/pyembroidery/ExpWriter.py
@@ -29,8 +29,8 @@ def write(pattern, f, settings=None):
             f.write(b'\x80\x04')
             f.write(bytes(bytearray([delta_x, delta_y])))
         elif data == TRIM:
-            f.write(b'\x80\x80\x07\x00')
-            continue
+            # not supported by file format
+            pass
         elif data == COLOR_CHANGE:
             f.write(b'\x80\x01\x00\x00')
             continue


### PR DESCRIPTION
This fixes https://github.com/inkstitch/inkstitch/issues/1315.
ExpReader still handles the invalid trim command but I dont know if thats a problem.