### PR TITLE
Count stop commands as color changes

### DIFF
--- a/pyembroidery/DstWriter.py
+++ b/pyembroidery/DstWriter.py
@@ -121,8 +121,8 @@ def write(pattern, f, settings=None):
 
     write_string_utf8(f, "LA:%-16s\r" % name)
     write_string_utf8(f, "ST:%7d\r" % pattern.count_stitches())
-    write_string_utf8(f, "CO:%3d\r" % pattern.count_color_changes())
-
+    write_string_utf8(f, "CO:%3d\r" % (pattern.count_color_changes()
+                      + pattern.count_stitch_commands(STOP)))
     write_string_utf8(f, "+X:%5d\r" % abs(bounds[2]))
     write_string_utf8(f, "-X:%5d\r" % abs(bounds[0]))
     write_string_utf8(f, "+Y:%5d\r" % abs(bounds[3]))


### PR DESCRIPTION
No corresponding change is needed in `DstReader.py`, as stops and color changes are read as color changes in the .dst file.